### PR TITLE
Lazy build of PffArchive's internal tree structure

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -138,6 +138,7 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         logging-fstring-interpolation,
+        logging-format-interpolation,
         bad-continuation,  # formatting handled by black
         ungrouped-imports,  # import order handled by isort
         exception-escape,

--- a/libratom/cli/cli.py
+++ b/libratom/cli/cli.py
@@ -1,4 +1,4 @@
-# pylint: disable=unused-argument,logging-fstring-interpolation
+# pylint: disable=unused-argument
 """
 Command-line interface for libratom
 """

--- a/libratom/cli/subcommands.py
+++ b/libratom/cli/subcommands.py
@@ -1,4 +1,4 @@
-# pylint: disable=logging-fstring-interpolation,invalid-name
+# pylint: disable=invalid-name
 """
 The functions in this module are entry points for ratom sub-commands, e.g. `ratom entities ...`
 """

--- a/libratom/lib/concurrency.py
+++ b/libratom/lib/concurrency.py
@@ -1,4 +1,4 @@
-# pylint: disable=logging-fstring-interpolation,broad-except,too-few-public-methods
+# pylint: disable=broad-except,too-few-public-methods
 """
 Set of utilities for parallel execution of libratom code
 """

--- a/libratom/lib/core.py
+++ b/libratom/lib/core.py
@@ -7,7 +7,7 @@ from libratom.lib import MboxArchive, PffArchive
 from libratom.lib.exceptions import FileTypeError
 
 
-def open_mail_archive(path: Path) -> Optional[Union[PffArchive, MboxArchive]]:
+def open_mail_archive(path: Path, **kwargs) -> Optional[Union[PffArchive, MboxArchive]]:
 
     extension_type_mapping = {".pst": PffArchive, ".mbox": MboxArchive}
 
@@ -16,7 +16,7 @@ def open_mail_archive(path: Path) -> Optional[Union[PffArchive, MboxArchive]]:
     except KeyError:
         raise FileTypeError(f"Unable to open {path}. Unsupported file type.")
 
-    return archive_class(path)
+    return archive_class(path, **kwargs)
 
 
 def get_set_of_files(path: Path) -> Set[Path]:

--- a/libratom/lib/entities.py
+++ b/libratom/lib/entities.py
@@ -1,4 +1,4 @@
-# pylint: disable=broad-except,logging-fstring-interpolation,invalid-name,protected-access,consider-using-ternary,logging-format-interpolation
+# pylint: disable=broad-except,invalid-name,protected-access,consider-using-ternary
 """
 Set of utility functions that use spaCy to perform named entity recognition
 """

--- a/libratom/lib/pff.py
+++ b/libratom/lib/pff.py
@@ -143,6 +143,13 @@ class PffArchive(Archive):
         Returns:
             A pypff.message object
         """
+
+        try:
+            # Use internal tree if present
+            return self.tree.get_node(message_id).data
+        except AttributeError:
+            pass
+
         # fmt: off
         for folder in self.folders():
             messages = folder.sub_messages

--- a/libratom/lib/report.py
+++ b/libratom/lib/report.py
@@ -1,4 +1,4 @@
-# pylint: disable=broad-except,logging-fstring-interpolation,protected-access
+# pylint: disable=broad-except,protected-access
 """
 Set of utility functions to generate job related reports
 """

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring,invalid-name,no-member
 import email
 import hashlib
-import itertools
 import logging
 import os
 import tempfile
@@ -28,14 +27,10 @@ def test_version():
     assert libratom.__version__
 
 
-@pytest.mark.parametrize("skip_tree, expected", [(False, True), (True, False)])
-def test_pffarchive_load_from_file_object(sample_pst_file, skip_tree, expected):
+def test_pffarchive_load_from_file_object(sample_pst_file):
 
-    with sample_pst_file.open(mode="rb") as f, PffArchive(
-        f, skip_tree=skip_tree
-    ) as archive:
+    with sample_pst_file.open(mode="rb") as f, PffArchive(f) as archive:
         assert len([message for message in archive.messages()]) == 2668
-        assert bool(archive.tree) is expected
 
 
 def test_pffarchive_load_from_invalid_type():
@@ -134,10 +129,9 @@ def test_get_messages_with_bad_files(enron_dataset_part044):
     assert _count == 558
 
 
-@pytest.mark.parametrize("skip_tree", [False, True])
-def test_get_message_by_id(sample_pst_file, skip_tree):
-    with PffArchive(sample_pst_file, skip_tree=skip_tree) as archive:
-        for message in itertools.islice(archive.messages(), 10):
+def test_get_message_by_id(sample_pst_file):
+    with PffArchive(sample_pst_file) as archive:
+        for message in archive.messages():
             msg = archive.get_message_by_id(message.identifier)
             assert msg.identifier == message.identifier
             assert archive.format_message(msg) == archive.format_message(message)
@@ -145,8 +139,7 @@ def test_get_message_by_id(sample_pst_file, skip_tree):
 
 def test_get_message_by_id_with_bad_id(sample_pst_file):
     with PffArchive(sample_pst_file) as archive:
-        with pytest.raises(ValueError):
-            assert archive.get_message_by_id(1234)
+        assert archive.get_message_by_id(1234) is None
 
 
 def test_get_messages_with_bad_messages(enron_dataset_part012):

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring,invalid-name,no-member
 import email
 import hashlib
+import itertools
 import logging
 import os
 import tempfile
@@ -133,10 +134,13 @@ def test_get_messages_with_bad_files(enron_dataset_part044):
     assert _count == 558
 
 
-def test_get_message_by_id(sample_pst_file):
-    with PffArchive(sample_pst_file) as archive:
-        for message in archive.messages():
-            assert archive.get_message_by_id(message.identifier)
+@pytest.mark.parametrize("skip_tree", [False, True])
+def test_get_message_by_id(sample_pst_file, skip_tree):
+    with PffArchive(sample_pst_file, skip_tree=skip_tree) as archive:
+        for message in itertools.islice(archive.messages(), 10):
+            msg = archive.get_message_by_id(message.identifier)
+            assert msg.identifier == message.identifier
+            assert archive.format_message(msg) == archive.format_message(message)
 
 
 def test_get_message_by_id_with_bad_id(sample_pst_file):


### PR DESCRIPTION
A PffArchive object now only builds its internal tree the first time it is needed.
Building the tree adds some overhead when opening a pst file, but allows for faster direct message access.