### PR TITLE
Update project summary

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libratom
-summary = Set of Python tools for the RATOM project
+summary = Python library and supporting utilities to parse and process PST and mbox email sources
 description-file = README.md
 description-content-type = text/markdown
 url = https://github.com/libratom/libratom


### PR DESCRIPTION
This should update the project summary on PyPI at the top of the [page](https://pypi.org/project/libratom/0.2.1/) where it currently reads "Set of Python tools for the RATOM project"