### PR TITLE
Add optional internal tree to MboxArchive

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,6 +262,11 @@ def directory_of_mbox_files() -> Path:
 
 
 @pytest.fixture(scope="session")
+def sample_mbox_file(directory_of_mbox_files) -> Path:
+    yield next(directory_of_mbox_files.glob("*.mbox"))
+
+
+@pytest.fixture(scope="session")
 def utf8_message_with_no_cte_header() -> Message:
     """
     Returns:
@@ -283,4 +288,4 @@ def utf8_message_with_no_cte_header() -> Message:
 
 @pytest.fixture(scope="session")
 def mock_progress_callback() -> Callable:
-    return lambda *_, **__: None
+    yield lambda *_, **__: None

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -347,3 +347,15 @@ def test_attachments_mime_type_validation(enron_dataset, mock_progress_callback)
         if attachments:
             for attachment in attachments:
                 assert attachment.mime_type in media_types
+
+
+def test_get_mbox_message_by_id(sample_mbox_file):
+    with open_mail_archive(sample_mbox_file) as archive:
+        for index, message in enumerate(archive.messages(), start=1):
+            msg = archive.get_message_by_id(index)
+            assert archive.format_message(msg) == archive.format_message(message)
+
+
+def test_get_mbox_message_by_id_with_bad_id(sample_mbox_file):
+    with open_mail_archive(sample_mbox_file) as archive:
+        assert archive.get_message_by_id(1234) is None


### PR DESCRIPTION
Arguably trivial since mbox archives are flat, this brings feature parity with PffArchive and O(1) access to messages. Tree is lazily built upon the first attempt to access it.