### PR TITLE
Mime type validation

### DIFF
--- a/libratom/cli/utils.py
+++ b/libratom/cli/utils.py
@@ -17,14 +17,8 @@ from jsonschema import validate
 from packaging.version import parse
 from tabulate import tabulate
 
-from libratom import data
+from libratom.data import EML_DUMP_INPUT_SCHEMA
 from libratom.lib.core import get_spacy_models
-
-try:
-    from importlib import resources
-except ImportError:
-    # backport version for Python 3.6
-    import importlib_resources as resources
 
 
 class PathPath(click.Path):
@@ -207,11 +201,8 @@ def validate_eml_export_input(ctx, param, value: Path) -> Path:
     """
 
     try:
-        with value.open() as json_fp, resources.path(
-            data, "eml_dump_input.schema.json"
-        ) as schema_file, open(schema_file) as schema_fp:
-
-            validate(instance=json.load(json_fp), schema=json.load(schema_fp))
+        with value.open() as json_fp:
+            validate(instance=json.load(json_fp), schema=EML_DUMP_INPUT_SCHEMA)
 
     except Exception as exc:
         click.echo(click.style(f"{exc}\r\n", fg="red"), err=True)

--- a/libratom/data/__init__.py
+++ b/libratom/data/__init__.py
@@ -1,0 +1,16 @@
+"""
+Non-code files
+"""
+
+import json
+
+try:
+    from importlib import resources
+except ImportError:
+    # backport version for Python 3.6
+    import importlib_resources as resources
+
+
+with resources.path(__name__, "media_types.json") as media_types_file:
+    with open(media_types_file, "r") as fp:
+        MIME_TYPES = json.load(fp)

--- a/libratom/data/__init__.py
+++ b/libratom/data/__init__.py
@@ -13,4 +13,4 @@ except ImportError:
 
 with resources.path(__name__, "media_types.json") as media_types_file:
     with open(media_types_file, "r") as fp:
-        MIME_TYPES = json.load(fp)
+        MIME_TYPES = set(json.load(fp))

--- a/libratom/data/__init__.py
+++ b/libratom/data/__init__.py
@@ -11,8 +11,13 @@ except ImportError:
     import importlib_resources as resources
 
 
-# Load mime types for direct access
+# Load JSON data for direct access
 with resources.path(__name__, "media_types.json") as media_types_file, open(
     media_types_file, "r"
 ) as fp:
     MIME_TYPES = set(json.load(fp))
+
+with resources.path(__name__, "eml_dump_input.schema.json") as schema_file, open(
+    schema_file
+) as schema_fp:
+    EML_DUMP_INPUT_SCHEMA = json.load(schema_fp)

--- a/libratom/data/__init__.py
+++ b/libratom/data/__init__.py
@@ -11,6 +11,8 @@ except ImportError:
     import importlib_resources as resources
 
 
-with resources.path(__name__, "media_types.json") as media_types_file:
-    with open(media_types_file, "r") as fp:
-        MIME_TYPES = set(json.load(fp))
+# Load mime types for direct access
+with resources.path(__name__, "media_types.json") as media_types_file, open(
+    media_types_file, "r"
+) as fp:
+    MIME_TYPES = set(json.load(fp))

--- a/libratom/lib/pff.py
+++ b/libratom/lib/pff.py
@@ -12,6 +12,7 @@ from typing import Generator, List, Optional, Union
 import pypff
 from treelib import Tree
 
+from libratom.data import MIME_TYPES
 from libratom.lib.base import Archive, AttachmentMetadata
 
 logger = logging.getLogger(__name__)
@@ -192,13 +193,20 @@ class PffArchive(Archive):
         def get_mime_type(attachment):
             # pylint: disable=broad-except
             try:
-                return (
+                mime_type = (
                     attachment.record_sets[0]
                     .entries[14]
                     .data.decode("utf-16")
                     .rstrip("\0")
                 )
-            except Exception:
+
+                if mime_type not in MIME_TYPES:
+                    raise ValueError(f"Unknown mime type: {mime_type}")
+
+                return mime_type
+
+            except Exception as exc:
+                logger.info(exc, exc_info=True)
                 return ""
 
         return [

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -29,13 +29,6 @@ from libratom.lib.pff import PffArchive
 from libratom.lib.report import get_file_info, scan_files
 from libratom.models import FileReport
 
-try:
-    from importlib import resources
-except ImportError:
-    # backport version for Python 3.6
-    import importlib_resources as resources
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -357,3 +357,9 @@ def test_get_mbox_message_by_id(sample_mbox_file):
 def test_get_mbox_message_by_id_with_bad_id(sample_mbox_file):
     with open_mail_archive(sample_mbox_file) as archive:
         assert archive.get_message_by_id(1234) is None
+
+
+def test_get_attachment_metadata():
+    message = MagicMock(identifier=123, attachments=[MagicMock(name="foo", size="0")])
+
+    assert PffArchive.get_attachment_metadata(message)[0].mime_type == ""

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -339,7 +339,7 @@ def test_attachments_mime_type_validation(enron_dataset, mock_progress_callback)
                 try:
                     assert attachment.mime_type in MIME_TYPES
                 except AssertionError:
-                    # Some enron files have these non-official attachment types
+                    # Some enron files have these obsolete attachment types
                     assert attachment.mime_type in [
                         "application/msexcell",
                         "application/mspowerpoint",

--- a/tests/unit/test_libratom.py
+++ b/tests/unit/test_libratom.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring,invalid-name,no-member,unused-import
 import email
 import hashlib
-import json
 import logging
 import os
 from email import policy
@@ -339,7 +338,7 @@ def test_attachments_mime_type_validation(enron_dataset, mock_progress_callback)
             for attachment in attachments:
                 try:
                     assert attachment.mime_type in MIME_TYPES
-                except ValueError:
+                except AssertionError:
                     # Some enron files have these non-official attachment types
                     assert attachment.mime_type in [
                         "application/msexcell",


### PR DESCRIPTION
Perform partial mime type validation and return an empty string if the mime type doesn't start with one of the known registries ("application", "audio", "text", etc...). The reason to only validate the registry is that messages can have obsolete mime type strings that have been deprecated in the official spec, which we would want to preserve.