### PR TITLE
Report progress bar fix

### DIFF
--- a/libratom/lib/report.py
+++ b/libratom/lib/report.py
@@ -15,11 +15,7 @@ from sqlalchemy.orm.session import Session
 
 import libratom
 from libratom.lib.concurrency import get_messages, imap_job, worker_init
-from libratom.lib.core import (
-    RATOM_MSG_PROGRESS_STEP,
-    get_ratom_settings,
-    open_mail_archive,
-)
+from libratom.lib.core import get_ratom_settings, open_mail_archive
 from libratom.models import Attachment, Configuration, FileReport, Message
 
 logger = logging.getLogger(__name__)
@@ -161,13 +157,10 @@ def generate_report(
     # Load the file_report table for local lookup
     _file_reports = session.query(FileReport).all()  # noqa: F841
 
-    msg_count = 0
-
     try:
 
-        for msg_count, msg_info in enumerate(
-            get_messages(files, progress_callback=update_progress, with_content=False),
-            start=1,
+        for msg_info in get_messages(
+            files, progress_callback=update_progress, with_content=False
         ):
 
             # Extract results
@@ -201,13 +194,6 @@ def generate_report(
                     for attachment in attachments
                 ]
             )
-
-            # Update progress every N messages
-            if not msg_count % RATOM_MSG_PROGRESS_STEP:
-                update_progress(RATOM_MSG_PROGRESS_STEP)
-
-        # Update progress with remaining message count
-        update_progress(msg_count % RATOM_MSG_PROGRESS_STEP)
 
     except KeyboardInterrupt:
         logger.warning("Cancelling running task")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -479,6 +479,11 @@ def test_validate_eml_export_input(bad_eml_export_input):
 def test_ratom_emldump(cli_runner, enron_dataset_part004, good_eml_export_input):
     expected = Expected(status=0, tokens=[])
 
-    params = [f"-l{enron_dataset_part004}", str(good_eml_export_input)]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        params = [
+            f"-l{enron_dataset_part004}",
+            f"-o{tmpdir}",
+            str(good_eml_export_input),
+        ]
 
-    dump_eml_files(params, None, cli_runner, expected)
+        dump_eml_files(params, None, cli_runner, expected)


### PR DESCRIPTION
With an unrelated unit test edit that keeps the test from leaving files in the CWD